### PR TITLE
翻数と符数の組み合わせ制限機能を実装

### DIFF
--- a/script.js
+++ b/script.js
@@ -754,11 +754,15 @@ function updateFuInputForSpecialYaku() {
             btn.classList.add('disabled');
         });
     } else {
-        // 符数入力を有効化
-        document.querySelectorAll('[data-target="fuYaku"]').forEach(btn => {
-            btn.disabled = false;
-            btn.classList.remove('disabled');
-        });
+        // 特殊役がない場合でも、5翻以上なら符数入力は無効のまま
+        const totalHan = calculateTotalHanFromSelectedYaku();
+        if (totalHan < 5) {
+            // 5翻未満の場合のみ符数入力を有効化
+            document.querySelectorAll('[data-target="fuYaku"]').forEach(btn => {
+                btn.disabled = false;
+                btn.classList.remove('disabled');
+            });
+        }
     }
 }
 

--- a/script.js
+++ b/script.js
@@ -333,6 +333,10 @@ function initializeApp() {
     // 初期状態の符数制限を設定
     const initialHan = parseInt(hanInput.value);
     adjustFuForHanChange(initialHan);
+    
+    // 役選択モードの初期制限も設定
+    const totalHan = calculateTotalHanFromSelectedYaku();
+    adjustFuForYakuSelection(totalHan);
 }
 
 function setupEventListeners() {
@@ -378,9 +382,20 @@ function handleNumberInput(event) {
         adjustFuForHanChange(newValue);
         
     } else if (target === 'fu' || target === 'fuYaku') {
+        // 特殊役選択時は符数変更を無効化
+        if (target === 'fuYaku' && hasSpecialYaku()) {
+            return; // 特殊役が選択されている場合は符数変更を無効
+        }
+        
         // 符数変更時の制限チェック
-        const hanInputElement = target === 'fu' ? hanInput : document.getElementById('hanInput');
-        const currentHan = parseInt(hanInputElement.value);
+        let currentHan;
+        if (target === 'fu') {
+            // 手動入力モードの場合
+            currentHan = parseInt(hanInput.value);
+        } else {
+            // 役選択モードの場合
+            currentHan = calculateTotalHanFromSelectedYaku();
+        }
         const validFuList = validFuByHan[currentHan] || [];
         
         if (action === 'increase' && currentValue < 110) {
@@ -644,6 +659,9 @@ function handleInputModeChange(event) {
         yakuInputSection.style.display = 'block';
         // 特殊役の処理を適用
         updateFuInputForSpecialYaku();
+        // 一般的な翻数・符数制限を適用
+        const totalHan = calculateTotalHanFromSelectedYaku();
+        adjustFuForYakuSelection(totalHan);
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -171,6 +171,15 @@ body {
     transform: scale(0.95);
 }
 
+.number-btn:disabled,
+.number-btn.disabled {
+    background: #f5f5f5 !important;
+    color: #bbb !important;
+    border-color: #ddd !important;
+    cursor: not-allowed !important;
+    transform: none !important;
+}
+
 .number-input-group input {
     width: 80px;
     height: 44px;


### PR DESCRIPTION
## Summary
- 翻数に応じた符数の組み合わせ制限機能を実装
- 七対子の25符対応を追加
- 手動入力モードと役選択モードの両方で制限を適用
- 5翻以上・役満時の符数入力無効化を実装

## 主な変更内容
- scoreTableに七対子用の25符エントリを追加
- validFuByHanデータ構造で有効な翻数・符数組み合わせを定義
- 特殊役（七対子）の符数固定処理を実装
- 翻数変更時の符数自動調整機能を実装
- 役選択時の符数制限機能を実装
- 符数ボタンの無効化UI制御を追加

## Test plan
- [x] 手動入力モードで翻数変更時の符数制限動作確認
- [x] 役選択モードで役選択時の符数制限動作確認
- [ ] 七対子選択時の25符固定動作確認
- [x] 5翻以上選択時の符数入力無効化確認
- [x] 役満選択時の符数入力無効化確認
- [ ] 無効な組み合わせの自動調整動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)