### PR TITLE
七対子を含む役の点数計算エラーを修正 (#4)

### DIFF
--- a/script.js
+++ b/script.js
@@ -257,12 +257,14 @@ const scoreTable = [
     { han: 2, fu: 110, childRon: 7100, childTsumo: "1800/3600", parentRon: 10600, parentTsumo: "3600" },
     
     { han: 3, fu: 20, childRon: 2600, childTsumo: "700/1300", parentRon: 3900, parentTsumo: "1300" },
+    { han: 3, fu: 25, childRon: 3200, childTsumo: "800/1600", parentRon: 4800, parentTsumo: "1600" },
     { han: 3, fu: 30, childRon: 3900, childTsumo: "1000/2000", parentRon: 5800, parentTsumo: "2000" },
     { han: 3, fu: 40, childRon: 5200, childTsumo: "1300/2600", parentRon: 7700, parentTsumo: "2600" },
     { han: 3, fu: 50, childRon: 6400, childTsumo: "1600/3200", parentRon: 9600, parentTsumo: "3200" },
     { han: 3, fu: 60, childRon: 7700, childTsumo: "2000/3900", parentRon: 11600, parentTsumo: "3900" },
     
     { han: 4, fu: 20, childRon: 5200, childTsumo: "1300/2600", parentRon: 7700, parentTsumo: "2600" },
+    { han: 4, fu: 25, childRon: 6400, childTsumo: "1600/3200", parentRon: 9600, parentTsumo: "3200" },
     { han: 4, fu: 30, childRon: 7700, childTsumo: "2000/3900", parentRon: 11600, parentTsumo: "3900" },
     
     { han: 5, fu: 0, childRon: 8000, childTsumo: "2000/4000", parentRon: 12000, parentTsumo: "4000" },
@@ -280,8 +282,8 @@ const scoreTable = [
 const validFuByHan = {
     1: [30, 40, 50, 60, 70, 80, 90, 100, 110],
     2: [20, 25, 30, 40, 50, 60, 70, 80, 90, 100, 110],
-    3: [20, 30, 40, 50, 60],
-    4: [20, 30],
+    3: [20, 25, 30, 40, 50, 60],
+    4: [20, 25, 30],
     5: [], // 満貫以上は符数無関係
     6: [],
     7: [],


### PR DESCRIPTION
## Summary
- 七対子を含む役の組み合わせで「該当する点数が見つかりません」エラーが発生する問題を修正
- scoreTableに3翻25符と4翻25符のエントリを追加
- validFuByHanの3翻と4翻に25符を追加

## 修正内容
- **scoreTable**: 3翻25符（3200点）と4翻25符（6400点）を追加
- **validFuByHan**: 3翻と4翻の有効符数に25を追加

## 解決される問題
- 立直+七対子（3翻25符）が正常に計算される
- 一発+七対子（3翻25符）が正常に計算される
- 立直+一発+七対子（4翻25符）が正常に計算される
- ダブル立直+七対子（4翻25符）が正常に計算される

## Test plan
- [x] 七対子単体（2翻25符）の計算確認
- [x] 立直+七対子（3翻25符）の計算確認
- [x] 立直+一発+七対子（4翻25符）の計算確認
- [x] 麻雀の点数計算公式（符数 × 2^(翻数+2)）による検証

🤖 Generated with [Claude Code](https://claude.ai/code)