### PR TITLE
点数表のスマートフォン表示幅問題を修正

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -581,6 +581,27 @@ body {
     .yaku-category {
         padding: 12px;
     }
+    
+    /* 点数表のスマートフォン最適化 */
+    .score-table {
+        table-layout: fixed;
+        font-size: 12px;
+    }
+    
+    .score-table th,
+    .score-table td {
+        padding: 6px 3px;
+        word-break: break-all;
+        line-height: 1.2;
+    }
+    
+    /* 各列の幅制御 */
+    .score-table th:nth-child(1), .score-table td:nth-child(1) { width: 15%; } /* 翻数 */
+    .score-table th:nth-child(2), .score-table td:nth-child(2) { width: 15%; } /* 符数 */
+    .score-table th:nth-child(3), .score-table td:nth-child(3) { width: 18%; } /* 子ロン */
+    .score-table th:nth-child(4), .score-table td:nth-child(4) { width: 22%; } /* 子ツモ */
+    .score-table th:nth-child(5), .score-table td:nth-child(5) { width: 18%; } /* 親ロン */
+    .score-table th:nth-child(6), .score-table td:nth-child(6) { width: 12%; } /* 親ツモ */
 }
 
 @media (min-width: 769px) {

--- a/styles.css
+++ b/styles.css
@@ -598,12 +598,12 @@ body {
     }
     
     /* 各列の幅制御 */
-    .score-table th:nth-child(1), .score-table td:nth-child(1) { width: 13%; } /* 翻数 */
+    .score-table th:nth-child(1), .score-table td:nth-child(1) { width: 12%; } /* 翻数 */
     .score-table th:nth-child(2), .score-table td:nth-child(2) { width: 13%; } /* 符数 */
     .score-table th:nth-child(3), .score-table td:nth-child(3) { width: 18%; } /* 子ロン */
     .score-table th:nth-child(4), .score-table td:nth-child(4) { width: 23%; } /* 子ツモ */
     .score-table th:nth-child(5), .score-table td:nth-child(5) { width: 18%; } /* 親ロン */
-    .score-table th:nth-child(6), .score-table td:nth-child(6) { width: 15%; } /* 親ツモ */
+    .score-table th:nth-child(6), .score-table td:nth-child(6) { width: 16%; } /* 親ツモ */
 }
 
 @media (min-width: 769px) {

--- a/styles.css
+++ b/styles.css
@@ -586,6 +586,8 @@ body {
     .score-table {
         table-layout: fixed;
         font-size: 12px;
+        width: 94%;
+        margin: 0 auto;
     }
     
     .score-table th,

--- a/styles.css
+++ b/styles.css
@@ -596,12 +596,12 @@ body {
     }
     
     /* 各列の幅制御 */
-    .score-table th:nth-child(1), .score-table td:nth-child(1) { width: 15%; } /* 翻数 */
-    .score-table th:nth-child(2), .score-table td:nth-child(2) { width: 15%; } /* 符数 */
+    .score-table th:nth-child(1), .score-table td:nth-child(1) { width: 13%; } /* 翻数 */
+    .score-table th:nth-child(2), .score-table td:nth-child(2) { width: 13%; } /* 符数 */
     .score-table th:nth-child(3), .score-table td:nth-child(3) { width: 18%; } /* 子ロン */
-    .score-table th:nth-child(4), .score-table td:nth-child(4) { width: 22%; } /* 子ツモ */
+    .score-table th:nth-child(4), .score-table td:nth-child(4) { width: 23%; } /* 子ツモ */
     .score-table th:nth-child(5), .score-table td:nth-child(5) { width: 18%; } /* 親ロン */
-    .score-table th:nth-child(6), .score-table td:nth-child(6) { width: 12%; } /* 親ツモ */
+    .score-table th:nth-child(6), .score-table td:nth-child(6) { width: 15%; } /* 親ツモ */
 }
 
 @media (min-width: 769px) {


### PR DESCRIPTION
## 概要
Issue #3 「点数表のスマホ表示時表示幅について」の修正対応

## 問題
- スマートフォン表示時に点数表が画面幅をはみ出す
- 役一覧から点数表切り替え時に毎回縮小操作が必要

## 修正内容
- 点数表のスマートフォン専用CSS最適化を追加
- `table-layout: fixed`による各列の幅制御
- 文字サイズとパディングの最適化
- 長い文字列の改行許可設定

## 技術的詳細
- 子ツモ列（最長11文字）を22%幅に制限
- 文字サイズ: 14px → 12px
- パディング: 12px/8px → 6px/3px
- `word-break: break-all`で改行許可

## テスト
- [ ] iPhone SE (320px) での表示確認
- [ ] 一般的なスマートフォン (375px) での表示確認
- [ ] 役一覧↔点数表の切り替え動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)